### PR TITLE
Only toggle on-screen touchbar if it is enabled.

### DIFF
--- a/TouchBarServer/AppDelegate.m
+++ b/TouchBarServer/AppDelegate.m
@@ -255,7 +255,8 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
 }
 
 - (void)didPressModifierKey {
-    [self toggleTouchBarWindow];
+    if (self.screenEnable == YES)
+        [self toggleTouchBarWindow];
 }
 
 - (NSMutableDictionary *)keyCaptionsForCurrentInputSource {


### PR DESCRIPTION
The on-screen touchbar becomes visible even though it is not enabled.