### PR TITLE
Add option to Center Align the Touch Bar displayed on screen

### DIFF
--- a/TouchBarServer/AppDelegate.m
+++ b/TouchBarServer/AppDelegate.m
@@ -232,12 +232,6 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
             if (menuItem.action != @selector(changeScreenFixedLeft:)) continue;
             menuItem.state = _ScreenFixedLeft ? 1 : 0;
         }
-        
-        if (_ScreenFixedLeft) {
-            leftornot = YES;
-        } else {
-            leftornot = NO;
-        }
     }
 }
 - (void)setScreenFixedCenter:(BOOL)ScreenFixedCenter {
@@ -266,11 +260,6 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
             menuItem.state = _ScreenFixedRight ? 1 : 0;
         }
         
-        if (_ScreenFixedRight) {
-            rightornot = YES;
-        } else {
-            rightornot = NO;
-        }
     }
 }
 

--- a/TouchBarServer/AppDelegate.m
+++ b/TouchBarServer/AppDelegate.m
@@ -224,10 +224,7 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
         _ScreenFixedLeft = ScreenFixedLeft;
         [[NSUserDefaults standardUserDefaults] setObject:@(_ScreenFixedCenter) forKey:kUserDefaultsKeyScreenFixedCenter];
         [[NSUserDefaults standardUserDefaults] synchronize];
-        
-        //_screenSubMenuItem.state = _ScreenFixedLeft ? 1 : 0;
-        //[self disableCenterTick];
-        //[self disableRightTick];
+
         for (NSMenuItem *menuItem in _screenSubMenuItem.submenu.itemArray) {
             if (menuItem.action != @selector(changeScreenFixedLeft:)) continue;
             menuItem.state = _ScreenFixedLeft ? 1 : 0;
@@ -254,7 +251,6 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
         [[NSUserDefaults standardUserDefaults] setObject:@(_ScreenFixedRight) forKey:kUserDefaultsKeyScreenFixedRight];
         [[NSUserDefaults standardUserDefaults] synchronize];
         
-        //_screenSubMenuItem.state = _ScreenFixedRight ? 1 : 0;
         for (NSMenuItem *menuItem in _screenSubMenuItem.submenu.itemArray) {
             if (menuItem.action != @selector(changeScreenFixedRight:)) continue;
             menuItem.state = _ScreenFixedRight ? 1 : 0;
@@ -315,17 +311,14 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
 
 - (IBAction)changeScreenFixedLeft:(NSMenuItem *)sender {
     self.ScreenFixedLeft = (sender.state == 0);
-    //self.screenEnable = (sender.state == 0);
 }
 
 - (IBAction)changeScreenFixedCenter:(NSMenuItem *)sender {
     self.ScreenFixedCenter = (sender.state == 0);
-    //self.screenEnable = (sender.state == 0);
 }
 
 - (IBAction)changeScreenFixedRight:(NSMenuItem *)sender {
     self.ScreenFixedRight = (sender.state == 0);
-    //self.screenEnable = (sender.state == 0);
 }
 
 - (IBAction)changeRemoteMode:(NSMenuItem *)sender {

--- a/TouchBarServer/AppDelegate.m
+++ b/TouchBarServer/AppDelegate.m
@@ -29,6 +29,9 @@ extern BOOL DFRFoundationPostEventWithMouseActivity(NSEventType type, NSPoint p)
 static NSString * const kUserDefaultsKeyScreenEnable    = @"ScreenEnable";
 static NSString * const kUserDefaultsKeyScreenToggleKey = @"ScreenToggleKey";
 static NSString * const kUserDefaultsKeyRemoteEnable    = @"RemoteEnable";
+static NSString * const kUserDefaultsKeyScreenFixedLeft    = @"ScreenFixedLeft";
+static NSString * const kUserDefaultsKeyScreenFixedCenter    = @"ScreenFixedCenter";
+static NSString * const kUserDefaultsKeyScreenFixedRight    = @"ScreenFixedRight";
 static NSString * const kUserDefaultsKeyRemoteMode      = @"RemoteMode";
 static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
 
@@ -43,6 +46,9 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
 @property (nonatomic, assign) BOOL screenEnable;
 @property (nonatomic, assign) ModifierKey screenToggleKey;
 @property (nonatomic, assign) BOOL remoteEnable;
+@property (nonatomic, assign) BOOL ScreenFixedLeft;
+@property (nonatomic, assign) BOOL ScreenFixedCenter;
+@property (nonatomic, assign) BOOL ScreenFixedRight;
 @property (nonatomic, assign) OperatingMode remoteMode;
 @property (nonatomic, assign) Alignment remoteAlign;
 
@@ -114,7 +120,9 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
                                                               kUserDefaultsKeyScreenEnable: @YES,
                                                               kUserDefaultsKeyScreenToggleKey: @(ModifierKeyFn),
                                                               kUserDefaultsKeyRemoteEnable: @YES,
-                                                              kUserDefaultsKeyRemoteMode: @(OperatingModeDemo1),
+                                                              kUserDefaultsKeyScreenFixedLeft: @YES,
+                                                              kUserDefaultsKeyScreenFixedCenter: @YES,
+                                                              kUserDefaultsKeyScreenFixedRight: @YES,kUserDefaultsKeyRemoteMode: @(OperatingModeDemo1),
                                                               kUserDefaultsKeyRemoteAlign: @(AlignmentBottom),
                                                               }];
 
@@ -126,6 +134,15 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
     
     _remoteEnable = NO;
     self.remoteEnable = [[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsKeyRemoteEnable];
+    
+    _ScreenFixedLeft = NO;
+    self.ScreenFixedLeft = [[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsKeyScreenFixedLeft];
+    
+    _ScreenFixedCenter = NO;
+    self.ScreenFixedCenter = [[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsKeyScreenFixedCenter];
+    
+    _ScreenFixedRight = NO;
+    self.ScreenFixedRight = [[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsKeyScreenFixedRight];
     
     _remoteMode = -1;
     self.remoteMode = [[NSUserDefaults standardUserDefaults] integerForKey:kUserDefaultsKeyRemoteMode];
@@ -202,6 +219,67 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
     }
 }
 
+- (void)setScreenFixedLeft:(BOOL)ScreenFixedLeft {
+    if (_ScreenFixedLeft != ScreenFixedLeft) {
+        _ScreenFixedLeft = ScreenFixedLeft;
+        [[NSUserDefaults standardUserDefaults] setObject:@(_ScreenFixedCenter) forKey:kUserDefaultsKeyScreenFixedCenter];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+        
+        //_screenSubMenuItem.state = _ScreenFixedLeft ? 1 : 0;
+        //[self disableCenterTick];
+        //[self disableRightTick];
+        for (NSMenuItem *menuItem in _screenSubMenuItem.submenu.itemArray) {
+            if (menuItem.action != @selector(changeScreenFixedLeft:)) continue;
+            menuItem.state = _ScreenFixedLeft ? 1 : 0;
+        }
+        
+        if (_ScreenFixedLeft) {
+            leftornot = YES;
+        } else {
+            leftornot = NO;
+        }
+    }
+}
+- (void)setScreenFixedCenter:(BOOL)ScreenFixedCenter {
+    if (_ScreenFixedCenter != ScreenFixedCenter) {
+        _ScreenFixedCenter = ScreenFixedCenter;
+        [[NSUserDefaults standardUserDefaults] setObject:@(_ScreenFixedCenter) forKey:kUserDefaultsKeyScreenFixedCenter];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+        
+        for (NSMenuItem *menuItem in _screenSubMenuItem.submenu.itemArray) {
+            if (menuItem.action != @selector(changeScreenFixedCenter:)) continue;
+            menuItem.state = _ScreenFixedCenter ? 1 : 0;
+        }
+        
+    }
+}
+
+- (void)setScreenFixedRight:(BOOL)ScreenFixedRight {
+    if (_ScreenFixedRight != ScreenFixedRight) {
+        _ScreenFixedRight = ScreenFixedRight;
+        [[NSUserDefaults standardUserDefaults] setObject:@(_ScreenFixedRight) forKey:kUserDefaultsKeyScreenFixedRight];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+        
+        //_screenSubMenuItem.state = _ScreenFixedRight ? 1 : 0;
+        for (NSMenuItem *menuItem in _screenSubMenuItem.submenu.itemArray) {
+            if (menuItem.action != @selector(changeScreenFixedRight:)) continue;
+            menuItem.state = _ScreenFixedRight ? 1 : 0;
+        }
+        
+        if (_ScreenFixedRight) {
+            rightornot = YES;
+        } else {
+            rightornot = NO;
+        }
+    }
+}
+
+- (void)disableRightTick:(BOOL)ScreenFixedRight {
+    for (NSMenuItem *menuItem in _screenSubMenuItem.submenu.itemArray) {
+        menuItem.state = 0;
+    }
+}
+
 - (void)setRemoteMode:(OperatingMode)remoteMode {
     if (_remoteMode != remoteMode) {
         _remoteMode = remoteMode;
@@ -244,6 +322,21 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
 
 - (IBAction)changeRemoteEnable:(NSMenuItem *)sender {
     self.remoteEnable = (sender.state == 0);
+}
+
+- (IBAction)changeScreenFixedLeft:(NSMenuItem *)sender {
+    self.ScreenFixedLeft = (sender.state == 0);
+    //self.screenEnable = (sender.state == 0);
+}
+
+- (IBAction)changeScreenFixedCenter:(NSMenuItem *)sender {
+    self.ScreenFixedCenter = (sender.state == 0);
+    //self.screenEnable = (sender.state == 0);
+}
+
+- (IBAction)changeScreenFixedRight:(NSMenuItem *)sender {
+    self.ScreenFixedRight = (sender.state == 0);
+    //self.screenEnable = (sender.state == 0);
 }
 
 - (IBAction)changeRemoteMode:(NSMenuItem *)sender {
@@ -327,7 +420,33 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
                 [_touchBarWindow setIsVisible:NO];
         }];
     } else {
-        [_touchBarWindow setFrameOrigin:self.mouseTouchOrigin];
+        
+        
+        if (_ScreenFixedCenter == YES) {
+            NSRect e = [[NSScreen mainScreen] frame];
+            int width = (int)e.size.width - 1095;
+            width = width/2;
+            NSPoint centerBottomPoint = CGPointMake(width, 0);
+            [_touchBarWindow setFrameOrigin:centerBottomPoint];
+        } else {
+            if (_ScreenFixedLeft == YES) {
+                NSRect e = [[NSScreen mainScreen] frame];
+                int width = (int)e.size.width - 10950;
+                width = width/2;
+                NSPoint centerBottomPoint = CGPointMake(width, 0);
+                [_touchBarWindow setFrameOrigin:centerBottomPoint];
+            } else {
+                if (_ScreenFixedRight == YES) {
+                    NSRect e = [[NSScreen mainScreen] frame];
+                    int width = (int)e.size.width - 10;
+                    width = width/2;
+                    NSPoint centerBottomPoint = CGPointMake(width, 0);
+                    [_touchBarWindow setFrameOrigin:centerBottomPoint];
+                } else {
+                    [_touchBarWindow setFrameOrigin:self.mouseTouchOrigin];
+                }
+            }
+        }
         
         _touchBarWindow.alphaValue = 1.0;
         [_touchBarWindow setIsVisible:YES];

--- a/TouchBarServer/Base.lproj/MainMenu.xib
+++ b/TouchBarServer/Base.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2657" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16E163f" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -64,6 +64,25 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="changeScreenToggleKey:" target="Voe-Tx-rLC" id="k0B-ny-Zcv"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="Pz3-Ls-Eon"/>
+                            <menuItem title="Align Left" id="vsh-pW-lUm">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="changeScreenFixedLeft:" target="Voe-Tx-rLC" id="hbv-IT-woS"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Align Center" id="4eP-kY-XkL">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="changeScreenFixedCenter:" target="Voe-Tx-rLC" id="Ay5-BV-ZhC"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Align Right" id="y1K-wX-4pS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="changeScreenFixedRight:" target="Voe-Tx-rLC" id="2ef-ch-mcg"/>
                                 </connections>
                             </menuItem>
                         </items>
@@ -159,6 +178,7 @@
                     </connections>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="139.5" y="165.5"/>
         </menu>
     </objects>
 </document>


### PR DESCRIPTION
This pull request changes the following things:
- Add option for Left, Center, and Right Align in menubar, under On-Screen Touch Bar
- Change AppDelegate.m to add support for the new options

Current Bugs inside this Pull Request:
- ~~FIXED: Changing Center Align also changes the state of On-Screen Touch Bar~~
- Choosing a different option, e.g. Right Align, when one option, e.g. Center Align, is already ticked ticks both of them. Center Align takes priority followed by Left then Right when all 3 are ticked.

This pull request can be merged immediately, no changes required to original code.

@robbertkl 