### PR TITLE
Don't try creating an image if the surface is nil

### DIFF
--- a/TouchBarServer/AppDelegate.m
+++ b/TouchBarServer/AppDelegate.m
@@ -447,6 +447,7 @@ static NSString * const kUserDefaultsKeyRemoteAlign     = @"RemoteAlign";
                                                                                              IOSurfaceRef frameSurface,
                                                                                              CGDisplayStreamUpdateRef updateRef) {
         if (status != kCGDisplayStreamFrameStatusFrameComplete) return;
+        if (frameSurface == nil) return;
         
         IOSurfaceLock(frameSurface, kIOSurfaceLockReadOnly, nil);
         CIImage *image = [CIImage imageWithIOSurface:frameSurface];


### PR DESCRIPTION
When I deactivate the Client on an iPad (i.e. Home button), the Server crashes on my Mac.

The reason is that `SLSDFRDisplayStreamCreate` handler block provides nil `frameSurface` and no error.

```
TouchBarServer[5528:157215] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', 
reason: 'Invalid parameter not satisfying: ciImage != nil'
*** First throw call stack:
(
0   CoreFoundation          __exceptionPreprocess + 256
1   libobjc.A.dylib         objc_exception_throw + 48
2   CoreFoundation          +[NSException raise:format:arguments:] + 98
3   Foundation              -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 194
4   AppKit                  -[NSBitmapImageRep initWithCIImage:] + 577
5   TouchBarServer          __29-[AppDelegate startStreaming]_block_invoke + 176
6   DFRFoundation           DFRDisplayStream_FrameAvailable + 683
7   DFRFoundation           DFRDisplayStream_server + 286
8   libdispatch.dylib       dispatch_mig_server + 377
9   DFRFoundation           __42-[DFRDisplayStream initWithQueue:handler:]_block_invoke + 92
10  libdispatch.dylib       _dispatch_client_callout + 8
11  libdispatch.dylib       _dispatch_continuation_pop + 563
12  libdispatch.dylib       _dispatch_source_invoke + 2124
13  libdispatch.dylib       _dispatch_workloop_worker_thread + 691
14  libsystem_pthread.dylib _pthread_wqthread + 421
15  libsystem_pthread.dylib start_wqthread + 13
)
...
```

I’ve added a nil check to fix that.
 